### PR TITLE
Fix critical bugs in REFERENCES dictionary access

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -198,7 +198,7 @@ rule remove_phix:
         bbduk.sh \
             in1={input.r1} in2={input.r2} \
             out1={output.r1} out2={output.r2} \
-            ref={REFERENCES[phix]} \
+            ref={REFERENCES["phix"]} \
             k=31 hdist=1 \
             stats={output.stats} \
             threads={threads} \
@@ -272,7 +272,7 @@ rule remove_rrna:
         bbduk.sh \
             in1={input.r1} in2={input.r2} \
             out1={output.r1} out2={output.r2} \
-            ref={REFERENCES[rrna]} \
+            ref={REFERENCES["rrna"]} \
             k=31 \
             stats={output.stats} \
             threads={threads} \


### PR DESCRIPTION
Fixed two syntax errors where dictionary keys were accessed without quotes:
- Line 201 (remove_phix rule): Changed {REFERENCES[phix]} to {REFERENCES["phix"]}
- Line 275 (remove_rrna rule): Changed {REFERENCES[rrna]} to {REFERENCES["rrna"]}

These bugs would have caused KeyError exceptions at runtime when the pipeline attempted to access PhiX and rRNA reference files.