### PR TITLE
fix: expand .gitignore to cover all reference database files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,26 @@
 # Results and output
 results/
 data/
+
+# Reference databases (keep scripts and docs, ignore large files)
 resources/*.fasta
 resources/*.fa
 resources/*.fna
+resources/*.fasta.gz
+resources/*.fa.gz
+resources/*.fna.gz
+# Index files
+resources/*.mmi
+resources/*.fai
+resources/*.bwt
+resources/*.amb
+resources/*.ann
+resources/*.pac
+resources/*.sa
+# Keep documentation and scripts
+!resources/README.md
+!resources/*.sh
+!resources/VERSIONS.txt
 
 # Conda environments
 .conda/


### PR DESCRIPTION
Update .gitignore to comprehensively exclude large reference files while keeping scripts and documentation.

Changes:
- Add compressed file patterns (*.fasta.gz, *.fa.gz, *.fna.gz)
- Add index file patterns (*.mmi, *.fai, *.bwt, *.amb, *.ann, *.pac, *.sa)
- Explicitly keep scripts, README.md, and VERSIONS.txt with negation patterns
- Add comments for clarity

Why:
- Reference genomes can be 3+ GB and should never be committed
- Index files are auto-generated and can be large
- Scripts and documentation should be version controlled
- Prevents accidental commits of large files

Related to resources/ directory setup in PR #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)