### PR TITLE
Refactor assembly workflow: remove BBMerge, add flexible strategies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ Thumbs.db
 *.temp
 tmp/
 temp/
+
+# Experimental/personal scripts (not for repo)
+scripts/compare_assemblies_checkv.sh

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This Snakemake pipeline provides robust QC specifically designed for:
 ✅ **Statistical outlier detection** - IQR-based contamination QC with publication-quality visualizations
 ✅ **Optical duplicate removal** - Illumina patterned flow cell artifacts
 ✅ **Cross-contamination detection** - Primer B analysis for sample mixing issues
-✅ **Automated QC flagging** - Pass/fail criteria for each sample
+✅ **Automated QC assessment** - Quality categories (Excellent/Good/Concerning/Poor) for each sample
 ✅ **Rich HTML reporting** - Self-contained virome dashboard with interactive plots
 ✅ **Modular assembly** - Optional viral metagenome assembly (individual or coassembly strategies)
 ✅ **Flexible entry points** - Start from raw reads or previously cleaned reads
@@ -68,7 +68,7 @@ Raw Reads (NovaSeq FASTQ)
     ↓
 [10] Contamination analysis (statistical outlier detection + plots)
     ↓
-Clean reads + QC reports + Sample flags + Contamination plots
+Clean reads + QC reports + Quality metrics + Contamination plots
     ↓
     ↓ [OPTIONAL: Assembly Module]
     ↓
@@ -459,7 +459,7 @@ results/
 │   ├── virome_report.html     # Primary HTML QC dashboard
 │   ├── virome_report.json     # Machine-readable QC data
 │   ├── read_counts.tsv        # Read counts at each step
-│   ├── sample_qc_flags.tsv    # Pass/fail flags per sample
+│   ├── sample_qc_metrics.tsv  # Quality assessment metrics per sample
 │   ├── contamination_summary.tsv        # Contamination levels per sample
 │   ├── contamination_bars.png           # Bar plot with outliers highlighted
 │   ├── contamination_boxes.png          # Distribution box plots
@@ -510,19 +510,23 @@ Open `results/multiqc/multiqc_report.html` in a web browser.
 - **fastp**: Check adapter content, insert size distribution, duplication rates
 - **Read counts**: Track reads retained at each step
 
-### 2. Sample QC Flags
+### 2. Sample Quality Assessment
 
-Check `results/reports/sample_qc_flags.tsv`:
+Check `results/reports/sample_qc_metrics.tsv`:
 
 ```
-sample    enrichment_score  pass_enrichment  pass_host  pass_rrna  overall_pass  notes
-sample1   25.3              PASS             PASS       PASS       PASS          None
-sample2   3.2               FAIL             FAIL       PASS       FAIL          Low_enrichment(3.2);High_host(15.3%)
+sample    host_percent  rrna_percent  final_reads  quality_category  notes
+sample1   4.2          8.5           2500000      Excellent         None
+sample2   15.3         25.2          450000       Concerning        High_host(15.3%);High_rRNA(25.2%)
+sample3   2.1          12.4          150000       Good              Low_coverage(150000)
+sample4   28.7         45.1          80000        Poor              High_host(28.7%);High_rRNA(45.1%);Low_coverage(80000)
 ```
 
-**Interpretation:**
-- **PASS**: Sample meets all QC criteria
-- **FAIL**: Sample fails one or more criteria (check notes)
+**Quality Categories:**
+- **Excellent**: All metrics well within thresholds (≤5% host, ≤10% rRNA, ≥200K reads)
+- **Good**: All metrics pass basic thresholds but some approaching limits
+- **Concerning**: One metric exceeds threshold but sample may still be usable
+- **Poor**: Multiple metrics exceed thresholds, likely problematic sample
 - **WARNING**: Insufficient data to assess
 
 ### 3. Contamination Flagging (PhiX & Vector)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,16 +25,16 @@ pipeline:
   # Assembly strategy (only used if run_assembly=true)
   # Both strategies use a two-stage workflow: MEGAHIT -> Flye meta-assembly
   #
-  # "individual": Assemble each sample separately with MEGAHIT, then combine
-  #               all contigs via Flye meta-assembly (default, recommended)
-  # "custom_groups": Assemble user-defined groups with MEGAHIT, then combine
-  #                  all group contigs via Flye meta-assembly
+  # "by_sample": Assemble each sample separately with MEGAHIT, then combine
+  #              all contigs via Flye meta-assembly (default, recommended)
+  # "by_group": Assemble user-defined groups with MEGAHIT, then combine
+  #             all group contigs via Flye meta-assembly
   #
   # NOTE: Global "coassembly" has been removed - research shows it performs
-  # worst on all metrics. Use "individual" or "custom_groups" instead.
-  assembly_strategy: "individual"
+  # worst on all metrics. Use "by_sample" or "by_group" instead.
+  assembly_strategy: "by_sample"
 
-  # Groups file (required if assembly_strategy="custom_groups")
+  # Groups file (required if assembly_strategy="by_group")
   # TSV file with exactly 2 columns: sample_id and group_id
   # Example:
   #   sample001    patient_A
@@ -66,6 +66,13 @@ deduplication:
 
     # Note: Optical duplicates are ALWAYS removed (clumpify step)
     # This setting only controls PCR duplicate removal (dedupe.sh)
+
+# rRNA removal settings
+rrna_removal:
+  # Enable rRNA removal step (default: true)
+  # Disable for samples where rRNA is not expected (e.g., DNA-only protocols)
+  # or when you want to retain rRNA for downstream analysis
+  enabled: true
 
 # Reference databases
 references:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -23,9 +23,26 @@ pipeline:
   run_assembly: false
 
   # Assembly strategy (only used if run_assembly=true)
-  # "coassembly": Combine all samples into one assembly (recommended for viromes)
-  # "individual": Assemble each sample separately
-  assembly_strategy: "coassembly"
+  # Both strategies use a two-stage workflow: MEGAHIT -> Flye meta-assembly
+  #
+  # "individual": Assemble each sample separately with MEGAHIT, then combine
+  #               all contigs via Flye meta-assembly (default, recommended)
+  # "custom_groups": Assemble user-defined groups with MEGAHIT, then combine
+  #                  all group contigs via Flye meta-assembly
+  #
+  # NOTE: Global "coassembly" has been removed - research shows it performs
+  # worst on all metrics. Use "individual" or "custom_groups" instead.
+  assembly_strategy: "individual"
+
+  # Groups file (required if assembly_strategy="custom_groups")
+  # TSV file with exactly 2 columns: sample_id and group_id
+  # Example:
+  #   sample001    patient_A
+  #   sample002    patient_A
+  #   sample003    patient_B
+  #   sample004    patient_B
+  # See config/examples/sample_groups.tsv for a template
+  groups_file: null
 
   # If start_from="cleaned_reads", specify directory containing cleaned reads
   # Format: {sample}_R1.fastq.gz and {sample}_R2.fastq.gz

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -172,7 +172,6 @@ primer_b:
   bbduk_rc: {ktrim: "r", k: 16, mink: 9, rcomp: "f", ordered: "t", ow: "t"}
 
 # Simplified QC thresholds - 3 essential metrics only
-# ViromeQC enrichment scoring removed as redundant with contamination measurements
 qc_thresholds:
   max_host_percent: 10          # Maximum % host reads (VLP prep efficiency)
   max_rrna_percent: 20          # Maximum % rRNA contamination (biological contamination)
@@ -189,13 +188,12 @@ reporting:
   include_fastqc_details: true   # Include FastQC metrics in report
   outlier_detection_method: "iqr"  # Options: iqr, zscore, modified_zscore
 
-  # Quality scoring weights for sample ranking
+  # Quality scoring weights for sample ranking (DEPRECATED: Now using quality categories)
   quality_weights:
-    enrichment_score: 0.30       # ViromeQC enrichment weight
-    read_retention: 0.25         # Final read retention weight
-    phix_contamination: 0.20     # PhiX contamination weight (negative)
-    vector_contamination: 0.15   # Vector contamination weight (negative)
-    total_contamination: 0.10    # Total contamination weight (negative)
+    read_retention: 0.40         # Final read retention weight
+    phix_contamination: 0.25     # PhiX contamination weight (negative)
+    vector_contamination: 0.20   # Vector contamination weight (negative)
+    total_contamination: 0.15    # Total contamination weight (negative)
 
   # Visualization settings
   max_samples_in_plots: 100      # Limit for performance with large batches

--- a/config/config_auto_detect_example.yaml
+++ b/config/config_auto_detect_example.yaml
@@ -74,7 +74,6 @@ sample_auto_detection:
 
 # QC thresholds for flagging problematic samples
 qc_thresholds:
-  min_enrichment_score: 10      # ViromeQC enrichment score
   max_host_percent: 10          # Maximum % host reads (VLP failure if exceeded)
   max_rrna_percent: 20          # Maximum % rRNA after removal
   min_final_reads: 100000       # Minimum reads after all QC

--- a/config/config_multi_directory_example.yaml
+++ b/config/config_multi_directory_example.yaml
@@ -59,7 +59,6 @@ sample_auto_detection:
 
 # QC thresholds for flagging problematic samples
 qc_thresholds:
-  min_enrichment_score: 10      # ViromeQC enrichment score
   max_host_percent: 10          # Maximum % host reads (VLP failure if exceeded)
   max_rrna_percent: 20          # Maximum % rRNA after removal
   min_final_reads: 100000       # Minimum reads after all QC

--- a/config/config_recursive_example.yaml
+++ b/config/config_recursive_example.yaml
@@ -75,7 +75,6 @@ sample_auto_detection:
 
 # QC thresholds for flagging problematic samples
 qc_thresholds:
-  min_enrichment_score: 10      # ViromeQC enrichment score
   max_host_percent: 10          # Maximum % host reads (VLP failure if exceeded)
   max_rrna_percent: 20          # Maximum % rRNA after removal
   min_final_reads: 100000       # Minimum reads after all QC

--- a/config/examples/config_assembly_from_cleaned.yaml
+++ b/config/examples/config_assembly_from_cleaned.yaml
@@ -5,6 +5,12 @@
 # Use this when you already have cleaned reads from a previous QC run or
 # another pipeline.
 #
+# Two-Stage Assembly Workflow:
+#   Stage 1: MEGAHIT assemblies (per-sample or per-group)
+#   Stage 2: Rename contigs with unique IDs
+#   Stage 3: Concatenate all renamed contigs
+#   Stage 4: Flye meta-assembly for final polished output
+#
 # REQUIREMENTS:
 # - Cleaned reads must be in paired-end format:
 #   {sample}_R1.fastq.gz and {sample}_R2.fastq.gz
@@ -22,26 +28,33 @@ pipeline:
 
   # Assembly strategy (IMPORTANT: Choose based on your analysis goals)
   # ----------------------------------------------------------------------------
-  # "coassembly" (RECOMMENDED for viromes):
-  #   - Pools all samples into a single community assembly
-  #   - Better for detecting rare viruses (increased depth across samples)
-  #   - Creates shared reference for viral community analysis
-  #   - Compatible with phage-analysis pipeline and other downstream tools
-  #   - Output: Single contigs file at results/assembly/megahit/final.contigs.fa
+  # "individual" (DEFAULT, RECOMMENDED):
+  #   - Stage 1: MEGAHIT assembles each sample separately
+  #   - Stage 2-4: Contigs are renamed, concatenated, and meta-assembled with Flye
+  #   - Use for most virome studies
+  #   - Output: Final meta-assembled contigs + per-sample MEGAHIT assemblies
   #
-  # "individual":
-  #   - Assembles each sample separately
-  #   - Use when samples represent different conditions/timepoints
-  #   - Better for sample-specific strain resolution
-  #   - Output: Multiple contig files at results/assembly/per_sample/{sample}/final.contigs.fa
+  # "custom_groups":
+  #   - Stage 1: MEGAHIT assembles user-defined groups of related samples
+  #   - Stage 2-4: Contigs are renamed, concatenated, and meta-assembled with Flye
+  #   - Use when samples are biologically related (same patient, same treatment)
+  #   - Requires: groups_file parameter (TSV with sample_id and group_id columns)
+  #   - Output: Final meta-assembled contigs + per-group MEGAHIT assemblies
+  #
+  # NOTE: Global "coassembly" has been removed - research shows it performs
+  # worst on all assembly metrics. Use "individual" or "custom_groups" instead.
   # ----------------------------------------------------------------------------
-  assembly_strategy: "coassembly"
+  assembly_strategy: "individual"
 
-  cleaned_reads_dir: "path/to/cleaned/reads"  # ⚠️ UPDATE THIS PATH!
+  # Groups file (required only if assembly_strategy="custom_groups")
+  # See config/examples/sample_groups.tsv for format
+  # groups_file: "config/examples/sample_groups.tsv"
+
+  cleaned_reads_dir: "path/to/cleaned/reads"  # UPDATE THIS PATH!
 
 # Assembly parameters
 assembly:
-  min_contig_length: 1000       # Keep contigs >= 1kb
+  min_contig_length: 1000       # Keep contigs >= 1kb (MEGAHIT parameter)
 
 # Samples - specify manually or use auto-detection
 # NOTE: Sample names must match filenames in cleaned_reads_dir

--- a/config/examples/config_assembly_from_cleaned.yaml
+++ b/config/examples/config_assembly_from_cleaned.yaml
@@ -28,13 +28,13 @@ pipeline:
 
   # Assembly strategy (IMPORTANT: Choose based on your analysis goals)
   # ----------------------------------------------------------------------------
-  # "individual" (DEFAULT, RECOMMENDED):
+  # "by_sample" (DEFAULT, RECOMMENDED):
   #   - Stage 1: MEGAHIT assembles each sample separately
   #   - Stage 2-4: Contigs are renamed, concatenated, and meta-assembled with Flye
   #   - Use for most virome studies
   #   - Output: Final meta-assembled contigs + per-sample MEGAHIT assemblies
   #
-  # "custom_groups":
+  # "by_group":
   #   - Stage 1: MEGAHIT assembles user-defined groups of related samples
   #   - Stage 2-4: Contigs are renamed, concatenated, and meta-assembled with Flye
   #   - Use when samples are biologically related (same patient, same treatment)
@@ -42,11 +42,11 @@ pipeline:
   #   - Output: Final meta-assembled contigs + per-group MEGAHIT assemblies
   #
   # NOTE: Global "coassembly" has been removed - research shows it performs
-  # worst on all assembly metrics. Use "individual" or "custom_groups" instead.
+  # worst on all assembly metrics. Use "by_sample" or "by_group" instead.
   # ----------------------------------------------------------------------------
-  assembly_strategy: "individual"
+  assembly_strategy: "by_sample"
 
-  # Groups file (required only if assembly_strategy="custom_groups")
+  # Groups file (required only if assembly_strategy="by_group")
   # See config/examples/sample_groups.tsv for format
   # groups_file: "config/examples/sample_groups.tsv"
 

--- a/config/examples/config_full_pipeline.yaml
+++ b/config/examples/config_full_pipeline.yaml
@@ -55,7 +55,6 @@ sample_auto_detection:
 
 # QC thresholds
 qc_thresholds:
-  min_enrichment_score: 10
   max_host_percent: 10
   max_rrna_percent: 20
   min_final_reads: 100000

--- a/config/examples/config_full_pipeline.yaml
+++ b/config/examples/config_full_pipeline.yaml
@@ -1,8 +1,14 @@
 # =============================================================================
-# Example Config: Full Pipeline (QC + Assembly)
+# Example Config: Full Pipeline (QC + Two-Stage Assembly)
 # =============================================================================
-# This configuration runs both QC and assembly modules.
+# This configuration runs both QC and the two-stage assembly workflow.
 # Use this for a complete analysis from raw reads to assembled contigs.
+#
+# Two-Stage Assembly Workflow:
+#   Stage 1: MEGAHIT assemblies (per-sample or per-group)
+#   Stage 2: Rename contigs with unique IDs
+#   Stage 3: Concatenate all renamed contigs
+#   Stage 4: Flye meta-assembly for final polished output
 #
 # Usage: snakemake --configfile config/examples/config_full_pipeline.yaml
 # =============================================================================
@@ -16,24 +22,32 @@ pipeline:
 
   # Assembly strategy (IMPORTANT: Choose based on your analysis goals)
   # ----------------------------------------------------------------------------
-  # "coassembly" (RECOMMENDED for viromes):
-  #   - Pools all samples into a single community assembly
-  #   - Better for detecting rare viruses (increased depth across samples)
-  #   - Creates shared reference for viral community analysis
-  #   - Compatible with phage-analysis pipeline and other downstream tools
-  #   - Output: Single contigs file representing entire viral community
+  # "individual" (DEFAULT, RECOMMENDED):
+  #   - Stage 1: MEGAHIT assembles each sample separately
+  #   - Stage 2-4: Contigs are renamed, concatenated, and meta-assembled with Flye
+  #   - Use for most virome studies
+  #   - Output: Final meta-assembled contigs + per-sample MEGAHIT assemblies
   #
-  # "individual":
-  #   - Assembles each sample separately
-  #   - Use when samples represent different conditions/timepoints
-  #   - Better for sample-specific strain resolution
-  #   - Output: Multiple contig files, one per sample
+  # "custom_groups":
+  #   - Stage 1: MEGAHIT assembles user-defined groups of related samples
+  #   - Stage 2-4: Contigs are renamed, concatenated, and meta-assembled with Flye
+  #   - Use when samples are biologically related (same patient, same treatment)
+  #   - Requires: groups_file parameter (TSV with sample_id and group_id columns)
+  #   - Keep groups to ~10 samples or fewer for best assembly quality
+  #   - Output: Final meta-assembled contigs + per-group MEGAHIT assemblies
+  #
+  # NOTE: Global "coassembly" has been removed - research shows it performs
+  # worst on all assembly metrics. Use "individual" or "custom_groups" instead.
   # ----------------------------------------------------------------------------
-  assembly_strategy: "coassembly"
+  assembly_strategy: "individual"
+
+  # Groups file (required only if assembly_strategy="custom_groups")
+  # See config/examples/sample_groups.tsv for format
+  # groups_file: "config/examples/sample_groups.tsv"
 
 # Assembly parameters
 assembly:
-  min_contig_length: 1000       # Keep contigs >= 1kb
+  min_contig_length: 1000       # Keep contigs >= 1kb (MEGAHIT parameter)
 
 # Quality filtering
 quality_threshold: 20
@@ -43,6 +57,8 @@ min_read_length: 100
 references:
   phix: "workflow/databases/phix174.fasta"
   vector_contaminants: "workflow/databases/vector_contaminants.fa"
+  primer_b_forward: "workflow/databases/primerB.fa"
+  primer_b_rc: "workflow/databases/primerB_rc.fa"
   host_genome: "resources/host_genome.fasta"
   rrna: "resources/silva_rrna.fasta"
 

--- a/config/examples/config_full_pipeline.yaml
+++ b/config/examples/config_full_pipeline.yaml
@@ -22,13 +22,13 @@ pipeline:
 
   # Assembly strategy (IMPORTANT: Choose based on your analysis goals)
   # ----------------------------------------------------------------------------
-  # "individual" (DEFAULT, RECOMMENDED):
+  # "by_sample" (DEFAULT, RECOMMENDED):
   #   - Stage 1: MEGAHIT assembles each sample separately
   #   - Stage 2-4: Contigs are renamed, concatenated, and meta-assembled with Flye
   #   - Use for most virome studies
   #   - Output: Final meta-assembled contigs + per-sample MEGAHIT assemblies
   #
-  # "custom_groups":
+  # "by_group":
   #   - Stage 1: MEGAHIT assembles user-defined groups of related samples
   #   - Stage 2-4: Contigs are renamed, concatenated, and meta-assembled with Flye
   #   - Use when samples are biologically related (same patient, same treatment)
@@ -37,11 +37,11 @@ pipeline:
   #   - Output: Final meta-assembled contigs + per-group MEGAHIT assemblies
   #
   # NOTE: Global "coassembly" has been removed - research shows it performs
-  # worst on all assembly metrics. Use "individual" or "custom_groups" instead.
+  # worst on all assembly metrics. Use "by_sample" or "by_group" instead.
   # ----------------------------------------------------------------------------
-  assembly_strategy: "individual"
+  assembly_strategy: "by_sample"
 
-  # Groups file (required only if assembly_strategy="custom_groups")
+  # Groups file (required only if assembly_strategy="by_group")
   # See config/examples/sample_groups.tsv for format
   # groups_file: "config/examples/sample_groups.tsv"
 

--- a/config/examples/config_qc_only.yaml
+++ b/config/examples/config_qc_only.yaml
@@ -34,7 +34,6 @@ sample_auto_detection:
 
 # QC thresholds
 qc_thresholds:
-  min_enrichment_score: 10
   max_host_percent: 10
   max_rrna_percent: 20
   min_final_reads: 100000

--- a/config/examples/sample_groups.tsv
+++ b/config/examples/sample_groups.tsv
@@ -1,0 +1,25 @@
+# Sample Groups File for Custom Assembly Strategy
+# ================================================
+# TSV file with exactly 2 columns: sample_id and group_id
+# Each sample must belong to exactly one group
+# All samples in the pipeline must be present in this file
+#
+# Group recommendations:
+# - Group biologically related samples (same patient, same treatment, etc.)
+# - Keep groups to ~10 samples or fewer for best assembly quality
+# - Groups >10 samples will generate a warning but will still run
+#
+# Format: sample_id<TAB>group_id
+sample_id	group_id
+sample001	patient_A
+sample002	patient_A
+sample003	patient_A
+sample004	patient_B
+sample005	patient_B
+sample006	patient_C
+sample007	patient_C
+sample008	patient_C
+sample009	patient_C
+sample010	control
+sample011	control
+sample012	control

--- a/docs/HTCF_USAGE.md
+++ b/docs/HTCF_USAGE.md
@@ -275,7 +275,7 @@ Key outputs:
 ```
 results/
 ├── multiqc/multiqc_report.html         # Main QC dashboard
-├── reports/sample_qc_flags.tsv         # Pass/fail flags
+├── reports/sample_qc_metrics.tsv       # Quality assessment metrics
 ├── reports/read_counts.tsv             # Read counts per step
 ├── viromeqc/                           # ViromeQC scores
 ├── clean_reads/                        # Final clean FASTQ files
@@ -291,7 +291,7 @@ results/
 scp leranwang@login.htcf.wustl.edu:/path/to/lab-virome-QC/results/multiqc/multiqc_report.html .
 
 # Download QC flags
-scp leranwang@login.htcf.wustl.edu:/path/to/lab-virome-QC/results/reports/sample_qc_flags.tsv .
+scp leranwang@login.htcf.wustl.edu:/path/to/lab-virome-QC/results/reports/sample_qc_metrics.tsv .
 
 # Download all results (if small enough)
 scp -r leranwang@login.htcf.wustl.edu:/path/to/lab-virome-QC/results/ .

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -300,12 +300,12 @@ def get_final_outputs():
             expand(f"{OUTDIR}/bbmerge/{{sample}}_R2_unmerged.fastq.gz", sample=SAMPLES)
         )
 
-        # Final assembly output (same for both strategies - two-stage workflow)
+        # Final assembly output (strategy-specific paths for comparison)
         # The final output is the Flye meta-assembly
         outputs.extend([
-            f"{OUTDIR}/assembly/flye/assembly.fasta",
-            f"{OUTDIR}/assembly/final.contigs.fa",  # Convenience symlink to Flye output
-            f"{OUTDIR}/reports/assembly_stats.tsv"
+            f"{OUTDIR}/assembly/{ASSEMBLY_STRATEGY}/flye/assembly.fasta",
+            f"{OUTDIR}/assembly/{ASSEMBLY_STRATEGY}/final.contigs.fa",  # Convenience symlink to Flye output
+            f"{OUTDIR}/reports/assembly_stats_{ASSEMBLY_STRATEGY}.tsv"
         ])
 
     return outputs
@@ -392,8 +392,8 @@ onsuccess:
         print(f"  - QC reports: {OUTDIR}/reports/")
         print(f"  - Clean reads: {OUTDIR}/clean_reads/")
     if RUN_ASSEMBLY:
-        print(f"  - Final assembly (Flye meta-assembly): {OUTDIR}/assembly/final.contigs.fa")
-        print(f"  - Assembly stats: {OUTDIR}/reports/assembly_stats.tsv")
+        print(f"  - Final assembly (Flye): {OUTDIR}/assembly/{ASSEMBLY_STRATEGY}/final.contigs.fa")
+        print(f"  - Assembly stats: {OUTDIR}/reports/assembly_stats_{ASSEMBLY_STRATEGY}.tsv")
         if ASSEMBLY_STRATEGY == "individual":
             print(f"  - Per-sample MEGAHIT assemblies: {OUTDIR}/assembly/per_sample/*/final.contigs.fa")
         elif ASSEMBLY_STRATEGY == "custom_groups":

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -127,8 +127,8 @@ def get_final_outputs():
         outputs.extend([
             # Read count tracking
             f"{OUTDIR}/reports/read_counts.tsv",
-            # Sample QC flags
-            f"{OUTDIR}/reports/sample_qc_flags.tsv",
+            # Sample QC metrics
+            f"{OUTDIR}/reports/sample_qc_metrics.tsv",
             # Contamination flagging
             f"{OUTDIR}/reports/contamination_summary.tsv",
             f"{OUTDIR}/reports/contamination_bars.png",
@@ -202,8 +202,8 @@ def get_qc_outputs():
         outputs.extend([
             # Read count tracking
             f"{OUTDIR}/reports/read_counts.tsv",
-            # Sample QC flags
-            f"{OUTDIR}/reports/sample_qc_flags.tsv",
+            # Sample QC metrics
+            f"{OUTDIR}/reports/sample_qc_metrics.tsv",
             # Contamination flagging summary
             f"{OUTDIR}/reports/contamination_summary.tsv",
             # Contamination plots

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -132,8 +132,6 @@ def get_final_outputs():
             # Contamination flagging
             f"{OUTDIR}/reports/contamination_summary.tsv",
             f"{OUTDIR}/reports/contamination_bars.png",
-            f"{OUTDIR}/reports/contamination_boxes.png",
-            f"{OUTDIR}/reports/contamination_scatter.png",
             f"{OUTDIR}/reports/contamination_heatmap.png",
             # Primer B cross-contamination analysis
             f"{OUTDIR}/reports/primer_b_contamination_summary.tsv",
@@ -208,8 +206,6 @@ def get_qc_outputs():
             f"{OUTDIR}/reports/contamination_summary.tsv",
             # Contamination plots
             f"{OUTDIR}/reports/contamination_bars.png",
-            f"{OUTDIR}/reports/contamination_boxes.png",
-            f"{OUTDIR}/reports/contamination_scatter.png",
             f"{OUTDIR}/reports/contamination_heatmap.png",
             # Primer B cross-contamination analysis
             f"{OUTDIR}/reports/primer_b_contamination_summary.tsv",

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -44,7 +44,126 @@ REFERENCES = config["references"]
 PIPELINE_CONFIG = config.get("pipeline", {})
 START_FROM = PIPELINE_CONFIG.get("start_from", "raw_reads")
 RUN_ASSEMBLY = PIPELINE_CONFIG.get("run_assembly", False)
-ASSEMBLY_STRATEGY = PIPELINE_CONFIG.get("assembly_strategy", "coassembly")
+ASSEMBLY_STRATEGY = PIPELINE_CONFIG.get("assembly_strategy", "individual")
+GROUPS_FILE = PIPELINE_CONFIG.get("groups_file", None)
+
+# ================================================================================
+# Groups File Parser for Custom Groups Assembly
+# ================================================================================
+
+def parse_groups_file(groups_file_path, pipeline_samples):
+    """
+    Parse a sample groups TSV file and validate its contents.
+
+    Args:
+        groups_file_path: Path to the TSV file with sample_id and group_id columns
+        pipeline_samples: List of sample IDs from the pipeline
+
+    Returns:
+        dict: Mapping of sample_id -> group_id
+
+    Raises:
+        ValueError: If file format is invalid or samples are missing
+    """
+    import csv
+
+    if not os.path.exists(groups_file_path):
+        raise FileNotFoundError(
+            f"Groups file not found: {groups_file_path}\n"
+            "Please provide a valid TSV file with sample_id and group_id columns."
+        )
+
+    sample_to_group = {}
+    groups_to_samples = {}
+
+    with open(groups_file_path, 'r') as f:
+        reader = csv.reader(f, delimiter='\t')
+
+        for line_num, row in enumerate(reader, 1):
+            # Skip empty lines and comments
+            if not row or row[0].startswith('#'):
+                continue
+
+            # Skip header row if present
+            if line_num == 1 and row[0].lower() in ['sample_id', 'sample', 'sampleid']:
+                continue
+
+            # Validate exactly 2 columns
+            if len(row) != 2:
+                raise ValueError(
+                    f"Groups file format error at line {line_num}: Expected 2 columns (sample_id, group_id), "
+                    f"found {len(row)} columns.\n"
+                    f"Line content: {row}"
+                )
+
+            sample_id, group_id = row[0].strip(), row[1].strip()
+
+            if not sample_id or not group_id:
+                raise ValueError(
+                    f"Groups file format error at line {line_num}: Empty sample_id or group_id.\n"
+                    f"Line content: {row}"
+                )
+
+            # Check for duplicate sample assignments
+            if sample_id in sample_to_group:
+                raise ValueError(
+                    f"Duplicate sample in groups file: '{sample_id}' appears multiple times.\n"
+                    f"Each sample must belong to exactly one group."
+                )
+
+            sample_to_group[sample_id] = group_id
+
+            # Track samples per group for size warnings
+            if group_id not in groups_to_samples:
+                groups_to_samples[group_id] = []
+            groups_to_samples[group_id].append(sample_id)
+
+    # Validate all pipeline samples are present in groups file
+    missing_samples = set(pipeline_samples) - set(sample_to_group.keys())
+    if missing_samples:
+        raise ValueError(
+            f"The following samples from the pipeline are missing from the groups file:\n"
+            f"  {', '.join(sorted(missing_samples))}\n"
+            f"All pipeline samples must be assigned to a group."
+        )
+
+    # Warn about extra samples in groups file (not in pipeline)
+    extra_samples = set(sample_to_group.keys()) - set(pipeline_samples)
+    if extra_samples:
+        print(f"  Warning: Groups file contains samples not in pipeline (will be ignored):")
+        print(f"    {', '.join(sorted(extra_samples))}")
+
+    # Check for large groups and print warnings
+    for group_id, group_samples in groups_to_samples.items():
+        if len(group_samples) > 10:
+            print(f"  Warning: Group '{group_id}' has {len(group_samples)} samples.")
+            print(f"      Assembly quality may decrease with groups >10 samples")
+            print(f"      (see: https://github.com/yourusername/assembly-clustering-validation).")
+            print(f"      Consider splitting into smaller groups, or proceed if samples are highly related.")
+
+    return sample_to_group
+
+def get_groups_to_samples(sample_to_group):
+    """
+    Invert sample_to_group mapping to get groups_to_samples.
+
+    Args:
+        sample_to_group: dict mapping sample_id -> group_id
+
+    Returns:
+        dict: Mapping of group_id -> list of sample_ids
+    """
+    groups_to_samples = {}
+    for sample_id, group_id in sample_to_group.items():
+        if group_id not in groups_to_samples:
+            groups_to_samples[group_id] = []
+        groups_to_samples[group_id].append(sample_id)
+    return groups_to_samples
+
+# Initialize group mappings (will be populated during validation if custom_groups)
+SAMPLE_TO_GROUP = {}
+GROUPS_TO_SAMPLES = {}
+GROUP_IDS = []
 
 # ================================================================================
 # Configuration Validation
@@ -52,6 +171,7 @@ ASSEMBLY_STRATEGY = PIPELINE_CONFIG.get("assembly_strategy", "coassembly")
 
 def validate_config():
     """Validate pipeline configuration and provide helpful error messages"""
+    global SAMPLE_TO_GROUP, GROUPS_TO_SAMPLES, GROUP_IDS
 
     # Check start_from value
     valid_start_points = ["raw_reads", "cleaned_reads", "contigs"]
@@ -77,22 +197,42 @@ def validate_config():
             )
 
     # Check assembly strategy
-    valid_strategies = ["coassembly", "individual"]
+    # NOTE: "coassembly" has been removed - research shows it performs worst on all metrics
+    # The new two-stage workflow uses either "individual" or "custom_groups"
+    valid_strategies = ["individual", "custom_groups"]
     if ASSEMBLY_STRATEGY not in valid_strategies:
         raise ValueError(
             f"Invalid pipeline.assembly_strategy: '{ASSEMBLY_STRATEGY}'. "
-            f"Must be one of: {valid_strategies}"
+            f"Must be one of: {valid_strategies}\n"
+            f"Note: 'coassembly' has been removed - research shows global coassembly "
+            f"performs poorly. Use 'individual' (default) or 'custom_groups' instead."
         )
+
+    # Validate custom_groups configuration
+    if ASSEMBLY_STRATEGY == "custom_groups":
+        if not GROUPS_FILE:
+            raise ValueError(
+                "pipeline.assembly_strategy='custom_groups' but pipeline.groups_file not specified!\n"
+                "Please add: pipeline:\n  groups_file: 'path/to/sample_groups.tsv'"
+            )
+
+        # Parse and validate groups file
+        SAMPLE_TO_GROUP = parse_groups_file(GROUPS_FILE, SAMPLES)
+        GROUPS_TO_SAMPLES = get_groups_to_samples(SAMPLE_TO_GROUP)
+        GROUP_IDS = list(GROUPS_TO_SAMPLES.keys())
 
     # Warn if assembly is requested but starting from contigs
     if START_FROM == "contigs" and RUN_ASSEMBLY:
         print("WARNING: pipeline.run_assembly=true but start_from='contigs'. Assembly will be skipped.")
 
-    print(f"✓ Configuration valid")
+    print(f"  Configuration valid")
     print(f"  Start from: {START_FROM}")
     print(f"  Run assembly: {RUN_ASSEMBLY}")
     if RUN_ASSEMBLY:
         print(f"  Assembly strategy: {ASSEMBLY_STRATEGY}")
+        if ASSEMBLY_STRATEGY == "custom_groups":
+            print(f"  Groups file: {GROUPS_FILE}")
+            print(f"  Number of groups: {len(GROUP_IDS)}")
 
 # Run validation
 validate_config()
@@ -143,6 +283,11 @@ def get_final_outputs():
 
     # ===== Assembly Outputs =====
     # Include assembly outputs if assembly is requested and not starting from contigs
+    # NOTE: Both "individual" and "custom_groups" strategies use the two-stage workflow:
+    #   Stage 1: MEGAHIT assemblies (per-sample or per-group)
+    #   Stage 2: Rename contigs with unique IDs
+    #   Stage 3: Concatenate all renamed contigs
+    #   Stage 4: Flye meta-assembly
     if RUN_ASSEMBLY and START_FROM != "contigs":
         # BBMerge outputs (needed for assembly)
         outputs.extend(
@@ -155,18 +300,13 @@ def get_final_outputs():
             expand(f"{OUTDIR}/bbmerge/{{sample}}_R2_unmerged.fastq.gz", sample=SAMPLES)
         )
 
-        # Assembly outputs
-        if ASSEMBLY_STRATEGY == "coassembly":
-            outputs.extend([
-                f"{OUTDIR}/assembly/megahit/final.contigs.fa",
-                f"{OUTDIR}/assembly/final.contigs.fa",  # Convenience symlink
-                f"{OUTDIR}/reports/assembly_stats.tsv"
-            ])
-        elif ASSEMBLY_STRATEGY == "individual":
-            outputs.extend(
-                expand(f"{OUTDIR}/assembly/per_sample/{{sample}}/final.contigs.fa", sample=SAMPLES)
-            )
-            outputs.append(f"{OUTDIR}/reports/assembly_stats.tsv")
+        # Final assembly output (same for both strategies - two-stage workflow)
+        # The final output is the Flye meta-assembly
+        outputs.extend([
+            f"{OUTDIR}/assembly/flye/assembly.fasta",
+            f"{OUTDIR}/assembly/final.contigs.fa",  # Convenience symlink to Flye output
+            f"{OUTDIR}/reports/assembly_stats.tsv"
+        ])
 
     return outputs
 
@@ -235,7 +375,9 @@ onstart:
     print(f"  Start from: {START_FROM}")
     print(f"  Run assembly: {RUN_ASSEMBLY}")
     if RUN_ASSEMBLY:
-        print(f"  Assembly strategy: {ASSEMBLY_STRATEGY}")
+        print(f"  Assembly strategy: {ASSEMBLY_STRATEGY} (two-stage workflow)")
+        if ASSEMBLY_STRATEGY == "custom_groups" and GROUP_IDS:
+            print(f"  Custom groups: {len(GROUP_IDS)} groups defined")
     print(f"  Samples: {len(SAMPLES)}")
     print(f"  Output directory: {OUTDIR}")
     print("="*80 + "\n")
@@ -243,15 +385,17 @@ onstart:
 
 onsuccess:
     print("\n" + "="*80)
-    print("✓ Pipeline completed successfully!")
+    print("Pipeline completed successfully!")
     print("="*80)
     print(f"Outputs available in: {OUTDIR}")
     if START_FROM == "raw_reads":
         print(f"  - QC reports: {OUTDIR}/reports/")
         print(f"  - Clean reads: {OUTDIR}/clean_reads/")
     if RUN_ASSEMBLY:
-        if ASSEMBLY_STRATEGY == "coassembly":
-            print(f"  - Assembly: {OUTDIR}/assembly/megahit/final.contigs.fa")
-        else:
-            print(f"  - Assemblies: {OUTDIR}/assembly/per_sample/*/final.contigs.fa")
+        print(f"  - Final assembly (Flye meta-assembly): {OUTDIR}/assembly/final.contigs.fa")
+        print(f"  - Assembly stats: {OUTDIR}/reports/assembly_stats.tsv")
+        if ASSEMBLY_STRATEGY == "individual":
+            print(f"  - Per-sample MEGAHIT assemblies: {OUTDIR}/assembly/per_sample/*/final.contigs.fa")
+        elif ASSEMBLY_STRATEGY == "custom_groups":
+            print(f"  - Per-group MEGAHIT assemblies: {OUTDIR}/assembly/per_group/*/final.contigs.fa")
     print("="*80 + "\n")

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -44,7 +44,7 @@ REFERENCES = config["references"]
 PIPELINE_CONFIG = config.get("pipeline", {})
 START_FROM = PIPELINE_CONFIG.get("start_from", "raw_reads")
 RUN_ASSEMBLY = PIPELINE_CONFIG.get("run_assembly", False)
-ASSEMBLY_STRATEGY = PIPELINE_CONFIG.get("assembly_strategy", "individual")
+ASSEMBLY_STRATEGY = PIPELINE_CONFIG.get("assembly_strategy", "by_sample")
 GROUPS_FILE = PIPELINE_CONFIG.get("groups_file", None)
 
 # ================================================================================
@@ -198,21 +198,21 @@ def validate_config():
 
     # Check assembly strategy
     # NOTE: "coassembly" has been removed - research shows it performs worst on all metrics
-    # The new two-stage workflow uses either "individual" or "custom_groups"
-    valid_strategies = ["individual", "custom_groups"]
+    # The new two-stage workflow uses either "by_sample" or "by_group"
+    valid_strategies = ["by_sample", "by_group"]
     if ASSEMBLY_STRATEGY not in valid_strategies:
         raise ValueError(
             f"Invalid pipeline.assembly_strategy: '{ASSEMBLY_STRATEGY}'. "
             f"Must be one of: {valid_strategies}\n"
             f"Note: 'coassembly' has been removed - research shows global coassembly "
-            f"performs poorly. Use 'individual' (default) or 'custom_groups' instead."
+            f"performs poorly. Use 'by_sample' (default) or 'by_group' instead."
         )
 
-    # Validate custom_groups configuration
-    if ASSEMBLY_STRATEGY == "custom_groups":
+    # Validate by_group configuration
+    if ASSEMBLY_STRATEGY == "by_group":
         if not GROUPS_FILE:
             raise ValueError(
-                "pipeline.assembly_strategy='custom_groups' but pipeline.groups_file not specified!\n"
+                "pipeline.assembly_strategy='by_group' but pipeline.groups_file not specified!\n"
                 "Please add: pipeline:\n  groups_file: 'path/to/sample_groups.tsv'"
             )
 
@@ -230,7 +230,7 @@ def validate_config():
     print(f"  Run assembly: {RUN_ASSEMBLY}")
     if RUN_ASSEMBLY:
         print(f"  Assembly strategy: {ASSEMBLY_STRATEGY}")
-        if ASSEMBLY_STRATEGY == "custom_groups":
+        if ASSEMBLY_STRATEGY == "by_group":
             print(f"  Groups file: {GROUPS_FILE}")
             print(f"  Number of groups: {len(GROUP_IDS)}")
 
@@ -283,7 +283,7 @@ def get_final_outputs():
 
     # ===== Assembly Outputs =====
     # Include assembly outputs if assembly is requested and not starting from contigs
-    # NOTE: Both "individual" and "custom_groups" strategies use the two-stage workflow:
+    # NOTE: Both "by_sample" and "by_group" strategies use the two-stage workflow:
     #   Stage 1: MEGAHIT assemblies (per-sample or per-group)
     #   Stage 2: Rename contigs with unique IDs
     #   Stage 3: Concatenate all renamed contigs
@@ -376,7 +376,7 @@ onstart:
     print(f"  Run assembly: {RUN_ASSEMBLY}")
     if RUN_ASSEMBLY:
         print(f"  Assembly strategy: {ASSEMBLY_STRATEGY} (two-stage workflow)")
-        if ASSEMBLY_STRATEGY == "custom_groups" and GROUP_IDS:
+        if ASSEMBLY_STRATEGY == "by_group" and GROUP_IDS:
             print(f"  Custom groups: {len(GROUP_IDS)} groups defined")
     print(f"  Samples: {len(SAMPLES)}")
     print(f"  Output directory: {OUTDIR}")
@@ -394,8 +394,8 @@ onsuccess:
     if RUN_ASSEMBLY:
         print(f"  - Final assembly (Flye): {OUTDIR}/assembly/{ASSEMBLY_STRATEGY}/final.contigs.fa")
         print(f"  - Assembly stats: {OUTDIR}/reports/assembly_stats_{ASSEMBLY_STRATEGY}.tsv")
-        if ASSEMBLY_STRATEGY == "individual":
+        if ASSEMBLY_STRATEGY == "by_sample":
             print(f"  - Per-sample MEGAHIT assemblies: {OUTDIR}/assembly/per_sample/*/final.contigs.fa")
-        elif ASSEMBLY_STRATEGY == "custom_groups":
+        elif ASSEMBLY_STRATEGY == "by_group":
             print(f"  - Per-group MEGAHIT assemblies: {OUTDIR}/assembly/per_group/*/final.contigs.fa")
     print("="*80 + "\n")

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -289,17 +289,6 @@ def get_final_outputs():
     #   Stage 3: Concatenate all renamed contigs
     #   Stage 4: Flye meta-assembly
     if RUN_ASSEMBLY and START_FROM != "contigs":
-        # BBMerge outputs (needed for assembly)
-        outputs.extend(
-            expand(f"{OUTDIR}/bbmerge/{{sample}}_merged.fastq.gz", sample=SAMPLES)
-        )
-        outputs.extend(
-            expand(f"{OUTDIR}/bbmerge/{{sample}}_R1_unmerged.fastq.gz", sample=SAMPLES)
-        )
-        outputs.extend(
-            expand(f"{OUTDIR}/bbmerge/{{sample}}_R2_unmerged.fastq.gz", sample=SAMPLES)
-        )
-
         # Final assembly output (strategy-specific paths for comparison)
         # The final output is the Flye meta-assembly
         outputs.extend([

--- a/workflow/envs/flye.yaml
+++ b/workflow/envs/flye.yaml
@@ -1,0 +1,7 @@
+name: flye
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - flye=2.9.5

--- a/workflow/rules/assembly.smk
+++ b/workflow/rules/assembly.smk
@@ -29,14 +29,17 @@ def get_reads_for_assembly(wildcards):
     Get cleaned reads for assembly based on pipeline entry point.
 
     Returns paths to R1/R2 files depending on where pipeline starts.
+    Uses clean_reads symlinks which automatically point to the correct
+    final QC step based on config toggles (rRNA removal, PCR dedup).
     """
     start_from = config["pipeline"].get("start_from", "raw_reads")
 
     if start_from == "raw_reads":
-        # Use QC module outputs (rrna_removed = final clean reads)
+        # Use QC module outputs via clean_reads symlinks
+        # These automatically point to the correct final step based on config
         return {
-            "r1": f"{OUTDIR}/rrna_removed/{wildcards.sample}_R1.fastq.gz",
-            "r2": f"{OUTDIR}/rrna_removed/{wildcards.sample}_R2.fastq.gz"
+            "r1": f"{OUTDIR}/clean_reads/{wildcards.sample}_R1.fastq.gz",
+            "r2": f"{OUTDIR}/clean_reads/{wildcards.sample}_R2.fastq.gz"
         }
     elif start_from == "cleaned_reads":
         # Use user-provided cleaned reads
@@ -61,6 +64,8 @@ def get_group_reads_for_assembly(wildcards):
     Get reads for all samples in a group (for by_group strategy).
 
     Returns dict with lists of R1/R2 files for all samples in the group.
+    Uses clean_reads symlinks which automatically point to the correct
+    final QC step based on config toggles (rRNA removal, PCR dedup).
     """
     group_id = wildcards.group
     group_samples = GROUPS_TO_SAMPLES.get(group_id, [])
@@ -68,7 +73,7 @@ def get_group_reads_for_assembly(wildcards):
     start_from = config["pipeline"].get("start_from", "raw_reads")
 
     if start_from == "raw_reads":
-        base_dir = f"{OUTDIR}/rrna_removed"
+        base_dir = f"{OUTDIR}/clean_reads"
     elif start_from == "cleaned_reads":
         base_dir = config["pipeline"].get("cleaned_reads_dir")
     else:

--- a/workflow/rules/assembly.smk
+++ b/workflow/rules/assembly.smk
@@ -81,9 +81,12 @@ def get_group_reads_for_merging(wildcards):
     }
 
 
-def get_renamed_contigs_for_concatenation():
+def get_renamed_contigs_for_concatenation(wildcards):
     """
     Get all renamed contig files for concatenation based on assembly strategy.
+
+    Args:
+        wildcards: Snakemake wildcards object (unused but required for input functions)
 
     Returns list of renamed contig file paths.
     """

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -667,22 +667,23 @@ rule plot_primer_b_heatmap:
     script:
         "../scripts/plot_primer_b_heatmap.py"
 
-rule qc_flags:
+rule qc_metrics:
     """
-    Generate QC pass/fail flags for each sample based on:
-    - ViromeQC enrichment score
-    - % host reads
-    - % rRNA reads
-    - Final read count
+    Generate QC quality metrics for each sample based on:
+    - % host reads (VLP prep efficiency)
+    - % rRNA reads (biological contamination)
+    - Final read count after QC (sequencing depth)
+
+    Provides quality categories rather than binary pass/fail assessments.
     """
     input:
         read_counts = f"{OUTDIR}/reports/read_counts.tsv"
     output:
-        f"{OUTDIR}/reports/sample_qc_flags.tsv"
+        f"{OUTDIR}/reports/sample_qc_metrics.tsv"
     conda:
         "../envs/qc.yaml"
     script:
-        "../scripts/generate_qc_flags.py"
+        "../scripts/generate_qc_metrics.py"
 
 rule multiqc:
     """
@@ -699,8 +700,8 @@ rule multiqc:
         expand(f"{OUTDIR}/fastp/{{sample}}_fastp.json", sample=SAMPLES),
         # Read counts
         f"{OUTDIR}/reports/read_counts.tsv",
-        # QC flags
-        f"{OUTDIR}/reports/sample_qc_flags.tsv",
+        # QC metrics
+        f"{OUTDIR}/reports/sample_qc_metrics.tsv",
         # Contamination summary
         f"{OUTDIR}/reports/contamination_summary.tsv"
     output:
@@ -731,7 +732,7 @@ rule virome_report:
         # QC data sources
         read_counts=f"{OUTDIR}/reports/read_counts.tsv",
         contamination_summary=f"{OUTDIR}/reports/contamination_summary.tsv",
-        qc_flags=f"{OUTDIR}/reports/sample_qc_flags.tsv",
+        qc_metrics=f"{OUTDIR}/reports/sample_qc_metrics.tsv",
         primer_b_summary=f"{OUTDIR}/reports/primer_b_contamination_summary.tsv",
         # Plot files for report
         contamination_plots=[

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -612,8 +612,6 @@ rule plot_contamination:
         f"{OUTDIR}/reports/contamination_summary.tsv"
     output:
         f"{OUTDIR}/reports/contamination_bars.png",
-        f"{OUTDIR}/reports/contamination_boxes.png",
-        f"{OUTDIR}/reports/contamination_scatter.png",
         f"{OUTDIR}/reports/contamination_heatmap.png"
     params:
         output_prefix = f"{OUTDIR}/reports/contamination"

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -325,7 +325,7 @@ rule host_depletion:
     For VLP-enriched samples, high host contamination (>10%) indicates VLP prep failure
     This step serves dual purpose:
     1. Remove host sequences from analysis
-    2. QC metric for VLP enrichment success
+    2. QC metric for VLP prep efficiency
 
     Note: Now operates after primer B removal (PhiX/vector flagging doesn't filter reads)
     Note: Minimap2 loads host genome index (~12GB for human) plus read processing
@@ -465,9 +465,7 @@ rule remove_pcr_duplicates:
         grep -E "^(Input|Duplicates|Result)" {log} > {output.stats} || true
         """
 
-# ViromeQC rule removed - enrichment scoring was redundant with host/rRNA contamination metrics
-# This removes the most computationally expensive QC step (16GB memory, 6-hour runtime)
-# Quality assessment now relies on directly measurable metrics: host_percent, rrna_percent, final_reads
+# Quality assessment relies on directly measurable metrics: host_percent, rrna_percent, final_reads
 
 rule final_fastqc:
     """

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -720,11 +720,12 @@ rule multiqc:
 
 rule virome_report:
     """
-    Generate user-friendly virome QC report (replaces MultiQC)
+    Generate user-friendly virome QC reports (replaces MultiQC)
 
-    Creates both interactive HTML dashboard and structured JSON data
-    for virome-specific quality assessment with batch-level overview
-    and easy outlier identification.
+    Creates dual HTML outputs for different use cases:
+    - virome_report.html: Lightweight version with external images (~2-3MB)
+    - virome_report_standalone.html: Self-contained with embedded images (~16MB)
+    Plus structured JSON data for virome-specific quality assessment.
     """
     input:
         # QC data sources
@@ -742,6 +743,7 @@ rule virome_report:
         fastqc_files=expand(f"{OUTDIR}/fastqc/final/{{sample}}_R1_fastqc.zip", sample=SAMPLES)
     output:
         html_report=f"{OUTDIR}/reports/virome_report.html",
+        html_report_standalone=f"{OUTDIR}/reports/virome_report_standalone.html",
         json_data=f"{OUTDIR}/reports/virome_report_data.json"
     log:
         f"{OUTDIR}/logs/virome_report.log"

--- a/workflow/scripts/assembly_stats.py
+++ b/workflow/scripts/assembly_stats.py
@@ -199,7 +199,7 @@ def main():
     log_file = snakemake.log[0] if snakemake.log else None
 
     # Get assembly strategy
-    assembly_strategy = snakemake.params.get("strategy", "individual")
+    assembly_strategy = snakemake.params.get("strategy", "by_sample")
 
     results = []
 

--- a/workflow/scripts/generate_qc_metrics.py
+++ b/workflow/scripts/generate_qc_metrics.py
@@ -8,7 +8,7 @@ Evaluates samples based on 3 essential quality metrics:
 - Final read count after QC (sequencing depth)
 
 Provides quality categories (Excellent/Good/Concerning/Poor) based on practical
-thresholds rather than binary pass/fail assessments, allowing researchers to make
+thresholds using evidence-based quality categories, allowing researchers to make
 informed decisions about sample usability for their specific analysis goals.
 
 """

--- a/workflow/scripts/generate_qc_metrics.py
+++ b/workflow/scripts/generate_qc_metrics.py
@@ -19,8 +19,9 @@ from pathlib import Path
 
 # Quality assessment relies on direct contamination measurements
 
-def categorize_quality(host_pct: float, rrna_pct: float, final_reads: int,
-                      max_host_pct: float, max_rrna_pct: float, min_final_reads: int) -> str:
+def categorize_quality(host_pct: float, rrna_pct, final_reads: int,
+                      max_host_pct: float, max_rrna_pct: float, min_final_reads: int,
+                      rrna_enabled: bool = True) -> str:
     """
     Categorize sample quality based on practical thresholds
 
@@ -29,12 +30,20 @@ def categorize_quality(host_pct: float, rrna_pct: float, final_reads: int,
     - Good: All metrics pass but some approaching thresholds
     - Concerning: One metric exceeds threshold but sample still usable
     - Poor: Multiple metrics exceed thresholds, likely problematic
+
+    Note: If rrna_enabled is False, rRNA metrics are skipped in categorization.
     """
     host_excellent = host_pct <= max_host_pct * 0.5
     host_good = host_pct <= max_host_pct
 
-    rrna_excellent = rrna_pct <= max_rrna_pct * 0.5
-    rrna_good = rrna_pct <= max_rrna_pct
+    # Only evaluate rRNA if enabled
+    if rrna_enabled and rrna_pct != 'N/A':
+        rrna_excellent = rrna_pct <= max_rrna_pct * 0.5
+        rrna_good = rrna_pct <= max_rrna_pct
+    else:
+        # Skip rRNA evaluation when disabled
+        rrna_excellent = True
+        rrna_good = True
 
     reads_excellent = final_reads >= min_final_reads * 2
     reads_good = final_reads >= min_final_reads
@@ -69,6 +78,9 @@ def main():
     max_host_pct = thresholds.get('max_host_percent', 10)
     max_rrna_pct = thresholds.get('max_rrna_percent', 20)
     min_final = thresholds.get('min_final_reads', 100000)
+
+    # Check if rRNA removal is enabled
+    rrna_enabled = config.get('rrna_removal', {}).get('enabled', True)
 
     # Load read counts
     read_df = pd.read_csv(read_counts_file, sep='\t')
@@ -106,30 +118,37 @@ def main():
             metrics['host_percent'] = host_pct
 
             # Calculate % pure rRNA contamination (biological contamination only)
-            # Use the actual rrna_removed step count rather than combined processing losses
-            rrna_removed_step = sample_reads[sample_reads['step'] == 'rrna_removed']['reads']
-            if len(rrna_removed_step) > 0:
-                rrna_removed_count = rrna_removed_step.values[0]
-                # Pure rRNA contamination: reads lost during rRNA removal step only
-                rrna_contamination = host_depleted - rrna_removed_count
-                rrna_pct = (rrna_contamination / host_depleted) * 100 if host_depleted > 0 else 0
+            # Only calculate if rRNA removal is enabled
+            if rrna_enabled:
+                rrna_removed_step = sample_reads[sample_reads['step'] == 'rrna_removed']['reads']
+                if len(rrna_removed_step) > 0:
+                    rrna_removed_count = rrna_removed_step.values[0]
+                    # Pure rRNA contamination: reads lost during rRNA removal step only
+                    rrna_contamination = host_depleted - rrna_removed_count
+                    rrna_pct = (rrna_contamination / host_depleted) * 100 if host_depleted > 0 else 0
+                    metrics['rrna_percent'] = rrna_pct
+                else:
+                    # rRNA enabled but step not found - shouldn't happen, but handle gracefully
+                    metrics['rrna_percent'] = 'N/A'
+                    rrna_pct = 'N/A'
             else:
-                # Fallback to old method if rrna_removed step not found
-                rrna_contamination = host_depleted - clean_count
-                rrna_pct = (rrna_contamination / host_depleted) * 100 if host_depleted > 0 else 0
-            metrics['rrna_percent'] = rrna_pct
+                # rRNA removal disabled - mark as not measured
+                metrics['rrna_percent'] = 'N/A'
+                rrna_pct = 'N/A'
+
             metrics['final_reads'] = clean_count
 
             # Categorize overall quality
             metrics['quality_category'] = categorize_quality(
                 host_pct, rrna_pct, clean_count,
-                max_host_pct, max_rrna_pct, min_final
+                max_host_pct, max_rrna_pct, min_final,
+                rrna_enabled=rrna_enabled
             )
 
             # Add informational notes (not failure indicators)
             if host_pct > max_host_pct:
                 metrics['notes'].append(f'High_host({host_pct:.1f}%)')
-            if rrna_pct > max_rrna_pct:
+            if rrna_enabled and rrna_pct != 'N/A' and rrna_pct > max_rrna_pct:
                 metrics['notes'].append(f'High_rRNA({rrna_pct:.1f}%)')
             if clean_count < min_final:
                 metrics['notes'].append(f'Low_coverage({int(clean_count)})')

--- a/workflow/scripts/generate_qc_metrics.py
+++ b/workflow/scripts/generate_qc_metrics.py
@@ -11,15 +11,13 @@ Provides quality categories (Excellent/Good/Concerning/Poor) based on practical
 thresholds rather than binary pass/fail assessments, allowing researchers to make
 informed decisions about sample usability for their specific analysis goals.
 
-Note: ViromeQC enrichment scoring removed as redundant with direct contamination measurements
 """
 
 import pandas as pd
 import sys
 from pathlib import Path
 
-# ViromeQC parsing function removed - enrichment scoring no longer used
-# Quality assessment now relies on direct contamination measurements
+# Quality assessment relies on direct contamination measurements
 
 def categorize_quality(host_pct: float, rrna_pct: float, final_reads: int,
                       max_host_pct: float, max_rrna_pct: float, min_final_reads: int) -> str:

--- a/workflow/scripts/generate_virome_report.py
+++ b/workflow/scripts/generate_virome_report.py
@@ -8,8 +8,8 @@ dashboard and publication-ready PDF reports.
 
 Replaces MultiQC with virome-specific reporting focused on:
 - Batch-level overview and outlier identification
-- Clear pass/fail assessment
-- Sample ranking by quality metrics
+- Quality metric visualization and assessment
+- Sample ranking by practical metrics
 - Interactive exploration and static sharing
 """
 
@@ -65,9 +65,9 @@ class ViromeQCDataLoader:
         """Load contamination summary data"""
         return pd.read_csv(contamination_file, sep='\t')
 
-    def load_qc_flags(self, qc_flags_file: str) -> pd.DataFrame:
-        """Load QC pass/fail flags"""
-        return pd.read_csv(qc_flags_file, sep='\t')
+    def load_qc_metrics(self, qc_metrics_file: str) -> pd.DataFrame:
+        """Load QC quality metrics"""
+        return pd.read_csv(qc_metrics_file, sep='\t')
 
     def load_primer_b_data(self, primer_b_file: str) -> pd.DataFrame:
         """Load primer B contamination data"""
@@ -224,12 +224,12 @@ class ViromeQCReportGenerator:
         # Load individual data sources
         read_counts = self.loader.load_read_counts(self.inputs['read_counts'])
         contamination = self.loader.load_contamination_data(self.inputs['contamination_summary'])
-        qc_flags = self.loader.load_qc_flags(self.inputs['qc_flags'])
+        qc_metrics = self.loader.load_qc_metrics(self.inputs['qc_metrics'])
         primer_b = self.loader.load_primer_b_data(self.inputs['primer_b_summary'])
         # ViromeQC data loading removed - enrichment scoring no longer used
 
-        # Start with QC flags as the base (has all samples)
-        unified = qc_flags.set_index('sample')
+        # Start with QC metrics as the base (has all samples)
+        unified = qc_metrics.set_index('sample')
 
         # Merge other data sources
         if not read_counts.empty:
@@ -247,7 +247,7 @@ class ViromeQCReportGenerator:
         unified = unified.reset_index()
 
         # ViromeQC enrichment score correction logic removed - no longer needed
-        # QC flags now use simplified 3-metric system
+        # QC metrics now use simplified 3-metric system
 
         self.unified_data = unified
         print(f"Successfully loaded data for {len(unified)} samples")
@@ -491,7 +491,7 @@ def main():
     inputs = {
         'read_counts': snakemake.input.read_counts,
         'contamination_summary': snakemake.input.contamination_summary,
-        'qc_flags': snakemake.input.qc_flags,
+        'qc_metrics': snakemake.input.qc_metrics,
         'primer_b_summary': snakemake.input.primer_b_summary,
         'fastqc_files': snakemake.input.get('fastqc_files', [])
     }

--- a/workflow/scripts/plot_contamination.py
+++ b/workflow/scripts/plot_contamination.py
@@ -42,10 +42,11 @@ def plot_contamination_bars(df, output_prefix):
 
     # Smart scaling: For large datasets, focus on top contaminants
     if n_samples > 50:
-        # Sort by total contamination and take top 25 worst samples
+        # Sort by total contamination and take top N worst samples (configurable)
+        top_n = min(25, n_samples)  # Show up to 25 samples or all if fewer
         df_sorted = df.sort_values('total_contamination_percent', ascending=False)
-        df_display = df_sorted.head(25).sort_values('total_contamination_percent', ascending=True)
-        title_suffix = f"\nShowing Top 25 Highest Contamination (of {n_samples} total samples)"
+        df_display = df_sorted.head(top_n).sort_values('total_contamination_percent', ascending=True)
+        title_suffix = f"\nShowing Top {top_n} Highest Contamination (of {n_samples} total samples)"
         n_display = len(df_display)
     else:
         # Show all samples for smaller datasets

--- a/workflow/scripts/plot_contamination.py
+++ b/workflow/scripts/plot_contamination.py
@@ -428,18 +428,16 @@ def main():
     plt.rcParams['grid.color'] = '#E5E5E5'
     plt.rcParams['grid.alpha'] = 0.4
 
-    # Generate plots
+    # Generate plots (only those displayed in HTML report)
     print("\n" + "="*60)
-    print("GENERATING CONTAMINATION PLOTS WITH PROFESSIONAL STYLING")
+    print("GENERATING CONTAMINATION PLOTS FOR HTML REPORT")
     print("="*60 + "\n")
 
     plot_contamination_bars(df, output_prefix)
-    plot_contamination_boxes(df, output_prefix)
-    plot_contamination_scatter(df, output_prefix)
     plot_contamination_heatmap(df, output_prefix)
 
     print("\n" + "="*60)
-    print("CONTAMINATION PLOTS COMPLETE - STYLED TO MATCH rRNA HISTOGRAM")
+    print("CONTAMINATION PLOTS COMPLETE - BAR CHART AND HEATMAP FOR HTML")
     print("="*60 + "\n")
 
 

--- a/workflow/scripts/plot_primer_b_heatmap.py
+++ b/workflow/scripts/plot_primer_b_heatmap.py
@@ -48,9 +48,41 @@ heatmap_data = heatmap_data[sorted(heatmap_data.columns, key=natural_sort_key)]
 sample_order = summary_df.sort_values(['dominant_pb', 'sample'])['sample'].tolist()
 heatmap_data = heatmap_data.reindex(sample_order)
 
-# Create figure
-fig_height = max(8, len(heatmap_data) * 0.3)  # Scale height with number of samples
-fig_width = max(12, len(heatmap_data.columns) * 0.4)  # Scale width with number of primer B variants
+# Create figure with smart scaling for large datasets
+n_samples = len(heatmap_data)
+n_variants = len(heatmap_data.columns)
+
+# For large datasets, focus on contaminated samples + representative set
+if n_samples > 100:
+    print(f"Large dataset detected ({n_samples} samples). Focusing on contaminated samples and representatives.")
+
+    # Get contaminated samples
+    contaminated_samples = summary_df[summary_df['contamination_flag']]['sample'].tolist()
+
+    # Get a representative sample from each dominant primer B group (max 50 total)
+    dominant_groups = summary_df.groupby('dominant_pb')['sample'].apply(list)
+    representative_samples = []
+    for pb_variant, group_samples in dominant_groups.items():
+        # Take first sample from each group as representative
+        if group_samples:
+            representative_samples.append(group_samples[0])
+
+    # Combine contaminated + representatives, limit to reasonable size
+    focus_samples = list(set(contaminated_samples + representative_samples))
+    if len(focus_samples) > 80:  # Still too many, prioritize contaminated
+        focus_samples = contaminated_samples + representative_samples[:80-len(contaminated_samples)]
+
+    # Filter heatmap data to focus samples
+    heatmap_data = heatmap_data.loc[heatmap_data.index.intersection(focus_samples)]
+
+    # Add note to title
+    title_suffix = f"\nShowing {len(contaminated_samples)} contaminated + {len(focus_samples)-len(contaminated_samples)} representative samples (of {n_samples} total)"
+else:
+    title_suffix = ""
+
+# Calculate reasonable figure size with limits
+fig_height = max(8, min(len(heatmap_data) * 0.4, 40))  # Cap at 40 inches height
+fig_width = max(12, min(n_variants * 0.5, 20))  # Cap at 20 inches width
 
 fig, ax = plt.subplots(figsize=(fig_width, fig_height))
 
@@ -70,14 +102,14 @@ sns.heatmap(
 # Formatting
 ax.set_xlabel('Primer B Variant', fontsize=12, fontweight='bold')
 ax.set_ylabel('Sample', fontsize=12, fontweight='bold')
-ax.set_title('Primer B Cross-Contamination Heatmap\n(% of Primer B Reads per Variant)',
+ax.set_title(f'Primer B Cross-Contamination Heatmap\n(% of Primer B Reads per Variant){title_suffix}',
              fontsize=14, fontweight='bold', pad=20)
 
 # Rotate x-axis labels for readability
 plt.xticks(rotation=45, ha='right')
 plt.yticks(rotation=0, fontsize=8)
 
-# Add contamination flags as colored markers
+# Add contamination flags as colored markers for samples shown in heatmap
 contaminated_samples = summary_df[summary_df['contamination_flag']]['sample'].tolist()
 for i, sample in enumerate(heatmap_data.index):
     if sample in contaminated_samples:
@@ -95,9 +127,12 @@ plt.savefig(heatmap_output, dpi=300, bbox_inches='tight')
 plt.close()
 
 print("\n=== Heatmap Statistics ===")
-print(f"Samples: {len(heatmap_data)}")
+print(f"Total samples analyzed: {n_samples}")
+print(f"Samples shown in heatmap: {len(heatmap_data)}")
 print(f"Primer B variants: {len(heatmap_data.columns)}")
-print(f"Contaminated samples (marked with red !): {len(contaminated_samples)}")
+total_contaminated = len(contaminated_samples)
+shown_contaminated = len([s for s in contaminated_samples if s in heatmap_data.index])
+print(f"Contaminated samples (marked with red !): {shown_contaminated}/{total_contaminated} shown")
 
 # Print dominant primer B distribution
 print("\nDominant Primer B Distribution:")

--- a/workflow/scripts/plot_primer_b_heatmap.py
+++ b/workflow/scripts/plot_primer_b_heatmap.py
@@ -48,41 +48,13 @@ heatmap_data = heatmap_data[sorted(heatmap_data.columns, key=natural_sort_key)]
 sample_order = summary_df.sort_values(['dominant_pb', 'sample'])['sample'].tolist()
 heatmap_data = heatmap_data.reindex(sample_order)
 
-# Create figure with smart scaling for large datasets
+# Create figure with appropriate scaling
 n_samples = len(heatmap_data)
 n_variants = len(heatmap_data.columns)
 
-# For large datasets, focus on contaminated samples + representative set
-if n_samples > 100:
-    print(f"Large dataset detected ({n_samples} samples). Focusing on contaminated samples and representatives.")
-
-    # Get contaminated samples
-    contaminated_samples = summary_df[summary_df['contamination_flag']]['sample'].tolist()
-
-    # Get a representative sample from each dominant primer B group (max 50 total)
-    dominant_groups = summary_df.groupby('dominant_pb')['sample'].apply(list)
-    representative_samples = []
-    for pb_variant, group_samples in dominant_groups.items():
-        # Take first sample from each group as representative
-        if group_samples:
-            representative_samples.append(group_samples[0])
-
-    # Combine contaminated + representatives, limit to reasonable size
-    focus_samples = list(set(contaminated_samples + representative_samples))
-    if len(focus_samples) > 80:  # Still too many, prioritize contaminated
-        focus_samples = contaminated_samples + representative_samples[:80-len(contaminated_samples)]
-
-    # Filter heatmap data to focus samples
-    heatmap_data = heatmap_data.loc[heatmap_data.index.intersection(focus_samples)]
-
-    # Add note to title
-    title_suffix = f"\nShowing {len(contaminated_samples)} contaminated + {len(focus_samples)-len(contaminated_samples)} representative samples (of {n_samples} total)"
-else:
-    title_suffix = ""
-
-# Calculate reasonable figure size with limits
-fig_height = max(8, min(len(heatmap_data) * 0.4, 40))  # Cap at 40 inches height
-fig_width = max(12, min(n_variants * 0.5, 20))  # Cap at 20 inches width
+# Calculate reasonable figure size - show all samples but with reasonable scaling
+fig_height = max(8, len(heatmap_data) * 0.3)  # Scale height with number of samples
+fig_width = max(12, len(heatmap_data.columns) * 0.4)  # Scale width with number of primer B variants
 
 fig, ax = plt.subplots(figsize=(fig_width, fig_height))
 
@@ -102,14 +74,14 @@ sns.heatmap(
 # Formatting
 ax.set_xlabel('Primer B Variant', fontsize=12, fontweight='bold')
 ax.set_ylabel('Sample', fontsize=12, fontweight='bold')
-ax.set_title(f'Primer B Cross-Contamination Heatmap\n(% of Primer B Reads per Variant){title_suffix}',
+ax.set_title('Primer B Cross-Contamination Heatmap\n(% of Primer B Reads per Variant)',
              fontsize=14, fontweight='bold', pad=20)
 
 # Rotate x-axis labels for readability
 plt.xticks(rotation=45, ha='right')
 plt.yticks(rotation=0, fontsize=8)
 
-# Add contamination flags as colored markers for samples shown in heatmap
+# Add contamination flags as colored markers
 contaminated_samples = summary_df[summary_df['contamination_flag']]['sample'].tolist()
 for i, sample in enumerate(heatmap_data.index):
     if sample in contaminated_samples:
@@ -127,12 +99,9 @@ plt.savefig(heatmap_output, dpi=300, bbox_inches='tight')
 plt.close()
 
 print("\n=== Heatmap Statistics ===")
-print(f"Total samples analyzed: {n_samples}")
-print(f"Samples shown in heatmap: {len(heatmap_data)}")
+print(f"Samples: {len(heatmap_data)}")
 print(f"Primer B variants: {len(heatmap_data.columns)}")
-total_contaminated = len(contaminated_samples)
-shown_contaminated = len([s for s in contaminated_samples if s in heatmap_data.index])
-print(f"Contaminated samples (marked with red !): {shown_contaminated}/{total_contaminated} shown")
+print(f"Contaminated samples (marked with red !): {len(contaminated_samples)}")
 
 # Print dominant primer B distribution
 print("\nDominant Primer B Distribution:")

--- a/workflow/scripts/plot_primer_b_heatmap.py
+++ b/workflow/scripts/plot_primer_b_heatmap.py
@@ -45,7 +45,10 @@ def natural_sort_key(s):
 heatmap_data = heatmap_data[sorted(heatmap_data.columns, key=natural_sort_key)]
 
 # Sort rows by dominant primer B for better visualization
-sample_order = summary_df.sort_values(['dominant_pb', 'sample'])['sample'].tolist()
+# Only include samples that have primer B distribution data
+samples_with_data = set(heatmap_data.index)
+summary_with_data = summary_df[summary_df['sample'].isin(samples_with_data)]
+sample_order = summary_with_data.sort_values(['dominant_pb', 'sample'])['sample'].tolist()
 heatmap_data = heatmap_data.reindex(sample_order)
 
 # Create figure with appropriate scaling

--- a/workflow/templates/virome_report.html
+++ b/workflow/templates/virome_report.html
@@ -442,18 +442,18 @@
             {% if batch_statistics.total_samples > 100 %}
             <div class="alert alert-info" role="alert">
                 <h5><i class="bi bi-info-circle-fill"></i> Large Dataset Visualization Strategy</h5>
-                <p>With <strong>{{ batch_statistics.total_samples }}</strong> samples, some plots are optimized for readability:</p>
+                <p>With <strong>{{ batch_statistics.total_samples }}</strong> samples, visualizations are optimized for readability:</p>
                 <ul class="mb-2">
-                    <li><strong>Bar charts:</strong> Show top 25 highest contamination samples</li>
-                    <li><strong>Heatmaps:</strong> Show outliers + top contaminants + representative samples</li>
-                    <li><strong>Box & scatter plots:</strong> Include all {{ batch_statistics.total_samples }} samples</li>
+                    <li><strong>Distribution histograms:</strong> Include all {{ batch_statistics.total_samples }} samples</li>
+                    <li><strong>Bar chart:</strong> Shows top 25 highest contamination samples</li>
+                    <li><strong>Heatmap:</strong> Shows outliers + top contaminants + representative samples</li>
                 </ul>
-                <small class="text-muted"><i class="bi bi-lightbulb"></i> <strong>Why:</strong> This approach balances comprehensive analysis with readable visualizations for actionable insights.</small>
+                <small class="text-muted"><i class="bi bi-lightbulb"></i> <strong>Why:</strong> Distribution plots show the complete picture, while bar charts and heatmaps focus on actionable outliers.</small>
             </div>
             {% elif batch_statistics.total_samples > 50 %}
             <div class="alert alert-info" role="alert">
-                <h5><i class="bi bi-info-circle-fill"></i> Focused Bar Charts</h5>
-                <p>With <strong>{{ batch_statistics.total_samples }}</strong> samples, <strong>bar charts show the top 25 highest contamination samples</strong> for readability. Distribution plots (box plots) and scatter plots include all samples.</p>
+                <h5><i class="bi bi-info-circle-fill"></i> Focused Bar Chart</h5>
+                <p>With <strong>{{ batch_statistics.total_samples }}</strong> samples, the <strong>bar chart shows the top 25 highest contamination samples</strong> for readability. Distribution histograms include all samples.</p>
             </div>
             {% endif %}
 

--- a/workflow/templates/virome_report.html
+++ b/workflow/templates/virome_report.html
@@ -891,7 +891,7 @@
     <footer class="mt-5 py-3 border-top">
         <div class="container text-center text-muted">
             <small>
-                ViromeQC Report |
+                Virome QC Report |
                 <a href="#" data-bs-toggle="modal" data-bs-target="#methodologyModal">Statistical Methods</a> |
                 Generated on {{ current_timestamp }}
             </small>

--- a/workflow/templates/virome_report.html
+++ b/workflow/templates/virome_report.html
@@ -16,10 +16,14 @@
     <script src="https://cdn.plot.ly/plotly-2.26.0.min.js"></script>
 
     <style>
-        .status-pass { color: #28a745; font-weight: bold; }
-        .status-fail { color: #dc3545; font-weight: bold; }
         .status-warning { color: #ffc107; font-weight: bold; }
         .status-unknown { color: #6c757d; font-weight: bold; }
+
+        /* Quality category styling */
+        .quality-excellent { color: #28a745; font-weight: bold; }
+        .quality-good { color: #20c997; font-weight: bold; }
+        .quality-concerning { color: #ffc107; font-weight: bold; }
+        .quality-poor { color: #dc3545; font-weight: bold; }
 
         .outlier-highlight {
             background-color: #fff3cd !important;

--- a/workflow/templates/virome_report.html
+++ b/workflow/templates/virome_report.html
@@ -445,15 +445,15 @@
                 <p>With <strong>{{ batch_statistics.total_samples }}</strong> samples, visualizations are optimized for readability:</p>
                 <ul class="mb-2">
                     <li><strong>Distribution histograms:</strong> Include all {{ batch_statistics.total_samples }} samples</li>
-                    <li><strong>Bar chart:</strong> Shows top 25 highest contamination samples</li>
-                    <li><strong>Heatmap:</strong> Shows outliers + top contaminants + representative samples</li>
+                    <li><strong>Bar chart:</strong> Shows top highest contamination samples for readability</li>
+                    <li><strong>Heatmap:</strong> Shows all samples with contamination levels by type</li>
                 </ul>
-                <small class="text-muted"><i class="bi bi-lightbulb"></i> <strong>Why:</strong> Distribution plots show the complete picture, while bar charts and heatmaps focus on actionable outliers.</small>
+                <small class="text-muted"><i class="bi bi-lightbulb"></i> <strong>Why:</strong> Distribution plots show the complete picture, while bar charts focus on actionable outliers for readability.</small>
             </div>
             {% elif batch_statistics.total_samples > 50 %}
             <div class="alert alert-info" role="alert">
                 <h5><i class="bi bi-info-circle-fill"></i> Focused Bar Chart</h5>
-                <p>With <strong>{{ batch_statistics.total_samples }}</strong> samples, the <strong>bar chart shows the top 25 highest contamination samples</strong> for readability. Distribution histograms include all samples.</p>
+                <p>With <strong>{{ batch_statistics.total_samples }}</strong> samples, the <strong>bar chart shows the top highest contamination samples</strong> for readability. Distribution histograms include all samples.</p>
             </div>
             {% endif %}
 

--- a/workflow/templates/virome_report.html
+++ b/workflow/templates/virome_report.html
@@ -442,13 +442,18 @@
             {% if batch_statistics.total_samples > 100 %}
             <div class="alert alert-info" role="alert">
                 <h5><i class="bi bi-info-circle-fill"></i> Large Dataset Visualization Strategy</h5>
-                <p>With <strong>{{ batch_statistics.total_samples }}</strong> samples, contamination plots focus on <strong>outliers and top contaminants</strong> for clarity. Bar charts show the highest contamination samples, while heatmaps display a representative subset including all statistical outliers.</p>
-                <small class="text-muted"><i class="bi bi-lightbulb"></i> <strong>Why:</strong> This approach highlights actionable samples requiring attention while maintaining plot readability and fast loading times.</small>
+                <p>With <strong>{{ batch_statistics.total_samples }}</strong> samples, some plots are optimized for readability:</p>
+                <ul class="mb-2">
+                    <li><strong>Bar charts:</strong> Show top 25 highest contamination samples</li>
+                    <li><strong>Heatmaps:</strong> Show outliers + top contaminants + representative samples</li>
+                    <li><strong>Box & scatter plots:</strong> Include all {{ batch_statistics.total_samples }} samples</li>
+                </ul>
+                <small class="text-muted"><i class="bi bi-lightbulb"></i> <strong>Why:</strong> This approach balances comprehensive analysis with readable visualizations for actionable insights.</small>
             </div>
             {% elif batch_statistics.total_samples > 50 %}
             <div class="alert alert-info" role="alert">
-                <h5><i class="bi bi-info-circle-fill"></i> Focused Visualization</h5>
-                <p>With <strong>{{ batch_statistics.total_samples }}</strong> samples, contamination bar charts show the <strong>top 25 highest contamination samples</strong> for better readability. All samples are included in distribution plots and statistical analysis.</p>
+                <h5><i class="bi bi-info-circle-fill"></i> Focused Bar Charts</h5>
+                <p>With <strong>{{ batch_statistics.total_samples }}</strong> samples, <strong>bar charts show the top 25 highest contamination samples</strong> for readability. Distribution plots (box plots) and scatter plots include all samples.</p>
             </div>
             {% endif %}
 

--- a/workflow/templates/virome_report.html
+++ b/workflow/templates/virome_report.html
@@ -165,7 +165,15 @@
                     <div class="card-body text-center">
                         <h3 class="card-title text-primary">{{ batch_statistics.total_samples }}</h3>
                         <p class="card-text">Total Samples</p>
-                        <small class="text-muted">Processed successfully</small>
+                        <small class="text-muted">
+                            {% if batch_statistics.total_samples > 200 %}
+                                Large dataset - outlier-focused visualization
+                            {% elif batch_statistics.total_samples > 50 %}
+                                Medium dataset - top contaminants highlighted
+                            {% else %}
+                                Complete sample visualization
+                            {% endif %}
+                        </small>
                     </div>
                 </div>
 
@@ -360,10 +368,17 @@
             <div class="filter-buttons">
                 <button class="btn btn-outline-primary" id="filter-all">All Samples</button>
                 <button class="btn btn-outline-warning" id="filter-outliers">
-                    Outliers Only
+                    Outliers Only ({{ batch_statistics.outlier_count }})
                     <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
                        data-bs-title="Shows samples with quality scores, contamination levels, or read processing metrics that deviate significantly from the batch median (using IQR statistical method)"></i>
                 </button>
+                {% if batch_statistics.total_samples > 50 %}
+                <button class="btn btn-outline-danger" id="filter-high-contamination">
+                    High Contamination
+                    <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
+                       data-bs-title="Shows samples with highest PhiX + vector contamination levels requiring attention"></i>
+                </button>
+                {% endif %}
             </div>
 
             <!-- Sample Table -->
@@ -423,6 +438,20 @@
         <section id="contamination-analysis" class="mb-5">
             <h2 class="section-title">Contamination Analysis</h2>
 
+            <!-- Large Dataset Notification -->
+            {% if batch_statistics.total_samples > 100 %}
+            <div class="alert alert-info" role="alert">
+                <h5><i class="bi bi-info-circle-fill"></i> Large Dataset Visualization Strategy</h5>
+                <p>With <strong>{{ batch_statistics.total_samples }}</strong> samples, contamination plots focus on <strong>outliers and top contaminants</strong> for clarity. Bar charts show the highest contamination samples, while heatmaps display a representative subset including all statistical outliers.</p>
+                <small class="text-muted"><i class="bi bi-lightbulb"></i> <strong>Why:</strong> This approach highlights actionable samples requiring attention while maintaining plot readability and fast loading times.</small>
+            </div>
+            {% elif batch_statistics.total_samples > 50 %}
+            <div class="alert alert-info" role="alert">
+                <h5><i class="bi bi-info-circle-fill"></i> Focused Visualization</h5>
+                <p>With <strong>{{ batch_statistics.total_samples }}</strong> samples, contamination bar charts show the <strong>top 25 highest contamination samples</strong> for better readability. All samples are included in distribution plots and statistical analysis.</p>
+            </div>
+            {% endif %}
+
             <!-- Contamination Distribution -->
             <div class="row mb-3">
                 <div class="col-md-6">
@@ -455,8 +484,10 @@
                             <h5>Contamination Levels by Sample</h5>
                         </div>
                         <div class="card-body">
-                            {% if base64_images.contamination_bars %}
+                            {% if standalone_version and base64_images.contamination_bars %}
                             <img src="{{ base64_images.contamination_bars }}" alt="Contamination Bar Chart" class="img-fluid">
+                            {% elif not standalone_version and image_links.contamination_bars %}
+                            <img src="{{ image_links.contamination_bars }}" alt="Contamination Bar Chart" class="img-fluid">
                             {% else %}
                             <div class="text-center text-muted p-4">Contamination bar chart not available</div>
                             {% endif %}
@@ -473,8 +504,10 @@
                             <h5>Contamination Heatmap</h5>
                         </div>
                         <div class="card-body">
-                            {% if base64_images.contamination_heatmap %}
+                            {% if standalone_version and base64_images.contamination_heatmap %}
                             <img src="{{ base64_images.contamination_heatmap }}" alt="Contamination Heatmap" class="img-fluid">
+                            {% elif not standalone_version and image_links.contamination_heatmap %}
+                            <img src="{{ image_links.contamination_heatmap }}" alt="Contamination Heatmap" class="img-fluid">
                             {% else %}
                             <div class="text-center text-muted p-4">Contamination heatmap not available</div>
                             {% endif %}
@@ -495,8 +528,10 @@
                             </small>
                         </div>
                         <div class="card-body">
-                            {% if base64_images.primer_b_heatmap %}
+                            {% if standalone_version and base64_images.primer_b_heatmap %}
                             <img src="{{ base64_images.primer_b_heatmap }}" alt="Primer B Heatmap" class="img-fluid">
+                            {% elif not standalone_version and image_links.primer_b_heatmap %}
+                            <img src="{{ image_links.primer_b_heatmap }}" alt="Primer B Heatmap" class="img-fluid">
                             {% else %}
                             <div class="text-center text-muted p-4">Primer B heatmap not available</div>
                             {% endif %}
@@ -575,7 +610,24 @@
                     }
                 );
                 table.draw();
-                $('.btn-outline-primary, .btn-outline-warning').removeClass('active');
+                $('.btn-outline-primary, .btn-outline-warning, .btn-outline-danger').removeClass('active');
+                $(this).addClass('active');
+
+                // Remove custom filter after use
+                $.fn.dataTable.ext.search.pop();
+            });
+
+            $('#filter-high-contamination').click(function() {
+                // Filter for samples with high PhiX + Vector contamination (>1%)
+                $.fn.dataTable.ext.search.push(
+                    function(settings, data, dataIndex) {
+                        const sampleData = reportData.samples[dataIndex];
+                        const totalContamination = (sampleData.phix_percent || 0) + (sampleData.vector_percent || 0);
+                        return totalContamination > 1.0;
+                    }
+                );
+                table.draw();
+                $('.btn-outline-primary, .btn-outline-warning, .btn-outline-danger').removeClass('active');
                 $(this).addClass('active');
 
                 // Remove custom filter after use
@@ -891,9 +943,17 @@
     <footer class="mt-5 py-3 border-top">
         <div class="container text-center text-muted">
             <small>
-                Virome QC Report |
+                Virome QC Report
+                {% if standalone_version %}
+                <span class="badge bg-info ms-2">Standalone Version</span>
+                (Self-contained with embedded images for sharing)
+                {% else %}
+                <span class="badge bg-success ms-2">Lightweight Version</span>
+                (External images for fast loading)
+                {% endif %}
+                |
                 <a href="#" data-bs-toggle="modal" data-bs-target="#methodologyModal">Statistical Methods</a> |
-                Generated on {{ current_timestamp }}
+                Generated on {{ timestamp }}
             </small>
         </div>
     </footer>


### PR DESCRIPTION
## Summary

- **Remove BBMerge step** - MEGAHIT now takes paired-end reads directly, simplifying the pipeline
- **Add flexible assembly strategies** - `by_sample` and `by_group` options that can run side-by-side for comparison
- **Make rRNA removal optional** - New `rrna_removal.enabled` config toggle for DNA-only protocols
- **Handle empty assemblies gracefully** - Pipeline no longer fails when samples produce no contigs (common in ~5-10% of virome samples)
- **Improve QC reporting** - Quality categories replace binary pass/fail, better large dataset support, improved contamination plots

## Key Changes

### Assembly
- Remove `bbmerge` rule entirely; MEGAHIT uses R1/R2 directly
- Strategy-specific output paths (`assembly/{strategy}/`) allow running both strategies without overwriting
- Flye meta-assembly step for final polishing

### QC
- Contamination is flagged (`flag_phix`, `flag_univec`) rather than filtered
- Redesigned virome reports for large datasets
- Removed ViromeQC dead code and legacy references

### Configuration
- New `rrna_removal.enabled` option (default: true)
- Unified strategy naming: `by_sample`/`by_group`

## Test plan

- [ ] Dry run validates DAG builds correctly
- [ ] Test on small sample subset (2-3 samples)
- [ ] Verify full pipeline completes with reports generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)